### PR TITLE
Lambda_proxy mapping template

### DIFF
--- a/lib/deploy/events/apiGateway/methods.js
+++ b/lib/deploy/events/apiGateway/methods.js
@@ -60,7 +60,7 @@ const LAMBDA_PROXY_REQUEST_TEMPLATE = `
       "protocol": "$context.protocol",
       "stage": "$context.stage",
       "domainPrefix": "$context.domainPrefix",
-      "requestTimeEpoch": "$context.requestTimeEpoch",
+      "requestTimeEpoch": $context.requestTimeEpoch,
       "requestId": "$context.requestId",
       #set( $map = $context.identity )
       "identity": $loop,


### PR DESCRIPTION
Make requestTimeEpoch value a number in the default lambda_proxy mapping template. "requestTimeEpoch" is handled as a number in the AWS SDK for typed languages and causes parsing issues when using a typed language such as c#.